### PR TITLE
6to5 has changed its name to Babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 ES6Samples
 ==========
 
-A set of ECMAScript 6 examples as well as a Gulp file that converts them to ES5 using Traceur and/or 6To5.
+A set of ECMAScript 6 examples as well as a Gulp file that converts them to ES5 using Traceur and/or Babel.


### PR DESCRIPTION
The JavaScript transpiler 6to5 has changed its name to Babel.
