### PR TITLE
Fix: Function rest parameter condition check

### DIFF
--- a/samples/parameters.js
+++ b/samples/parameters.js
@@ -7,7 +7,7 @@
     //The year parameter is a "default parameter"
     setDetails(make = 'No Make', model = 'No Model', year = this.currentYear(), ...accessories) {
         console.log(make + ' ' + model + ' ' + year);  
-        if (accessories) {
+        if (accessories.length) {
             for (var i = 0; i < accessories.length; i++) {
                 console.log('\n' + accessories[i]);
             }


### PR DESCRIPTION
<details>
  <summary>Changelog</summary>
  

> Bug fix

- Corrected function rest parameter condition check
- The accessories is the rest parameter, which is always an **array**. So, the condition **if(accessories)** will always be true
</details>

<details>
  <summary>Commits</summary>
 

- [d0280aa](https://github.com/DanWahlin/ES2015Samples/pull/9/commits/d0280aa748c4e95a29b2923d0366a6c4e3d23974)

- See full diff in [compare view](https://github.com/DanWahlin/ES2015Samples/pull/9/files)

</details>